### PR TITLE
Add a Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1659610603,
+        "narHash": "sha256-LYgASYSPYo7O71WfeUOaEUzYfzuXm8c8eavJcel+pfI=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "c6a45e4277fa58abd524681466d3450f896dc094",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-nkMQ1TKIIAYIVbbUzjxfjPn3H1zZFW20TrHUFAjwvNU=",
+        "path": "/nix/store/c3qqpbi359a0dvx80bkhzyqgd839y5if-source",
+        "type": "path"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "naersk": "naersk",
+        "nixpkgs": [
+          "naersk",
+          "nixpkgs"
+        ]
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    naersk.url = "github:nix-community/naersk";
+    nixpkgs.follows = "naersk/nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, naersk }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        packageName = "simp";
+
+        pkgs = import nixpkgs {
+          inherit system;
+        };
+        deps = with pkgs; [
+          git
+          pkg-config
+          gtk3
+          xorg.libxcb
+          speechd
+          libxkbcommon
+          openssl
+          rustc
+          cargo
+        ];
+        naersk' = naersk.lib."${system}";
+      in
+      rec {
+        packages.${packageName} = naersk'.buildPackage {
+          pname = "${packageName}";
+          root = ./.;
+          nativeBuildInputs = deps ++ [ pkgs.wrapGAppsHook ];
+        };
+        defaultPackage = packages.${packageName};
+
+        apps.${packageName} = packages.${packageName};
+        defaultApp = apps.${packageName};
+
+        devShell = pkgs.mkShell {
+          buildInputs = deps ++ (with pkgs; [
+            rustfmt
+            clippy
+            rust-analyzer
+          ]);
+        };
+      }
+    );
+}


### PR DESCRIPTION
With this Nix (with flakes) users will be able to run `simp` with just `nix run github:Kl4rry/simp` and easily install the package. It also provides a configured developing environment for contributors.