### PR TITLE
Fix navigation keys

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -541,7 +541,7 @@ impl App {
                     }) && self.view_available()
                         && !self.image_view.as_ref().unwrap().cropping()
                     {
-                        self.queue(Op::Prev);
+                        self.queue(Op::Next);
                     }
 
                     if input.consume_shortcut(&KeyboardShortcut {
@@ -556,7 +556,7 @@ impl App {
                     }) && self.view_available()
                         && !self.image_view.as_ref().unwrap().cropping()
                     {
-                        self.queue(Op::Next);
+                        self.queue(Op::Prev);
                     }
 
                     if input.consume_shortcut(&KeyboardShortcut {


### PR DESCRIPTION
Navigation keys were backwards. Left went to the next image and right went to the previous image. Changed it to the standard order which is left goes to the previous image and right goes to the next image.